### PR TITLE
계층 권한 설정

### DIFF
--- a/src/main/java/com/jisu/adminspringsecurity/domain/entity/RoleHierarchy.java
+++ b/src/main/java/com/jisu/adminspringsecurity/domain/entity/RoleHierarchy.java
@@ -1,0 +1,33 @@
+package com.jisu.adminspringsecurity.domain.entity;
+
+import lombok.*;
+
+import javax.persistence.*;
+import java.io.Serializable;
+import java.util.HashSet;
+import java.util.Set;
+
+@Entity
+@Table(name="ROLE_HIERARCHY")
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+@Builder
+@ToString(exclude = {"parentName", "roleHierarchy"})
+//@JsonIdentityInfo(generator = ObjectIdGenerators.IntSequenceGenerator.class)
+public class RoleHierarchy implements Serializable {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @Column(name = "child_name")
+    private String childName;
+
+    @ManyToOne(cascade = {CascadeType.ALL},fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_name", referencedColumnName = "child_name")
+    private RoleHierarchy parentName;
+
+    @OneToMany(mappedBy = "parentName", cascade={CascadeType.ALL})
+    private Set<RoleHierarchy> roleHierarchy = new HashSet<RoleHierarchy>();
+}

--- a/src/main/java/com/jisu/adminspringsecurity/repository/ResourcesRepository.java
+++ b/src/main/java/com/jisu/adminspringsecurity/repository/ResourcesRepository.java
@@ -9,7 +9,7 @@ import java.util.List;
 
 public interface ResourcesRepository extends JpaRepository<Resources, Long> {
 
-//    Resources findByResourceNameAndHttpMethod(String resourceName, String httpMethod);
+    Resources findByResourceNameAndHttpMethod(String resourceName, String httpMethod);
 
     @Query("select r from Resources r join fetch r.roleSet where r.resourceType = 'url' order by r.orderNum desc")
     List<Resources> findAllResources();

--- a/src/main/java/com/jisu/adminspringsecurity/repository/RoleHierarchyRepository.java
+++ b/src/main/java/com/jisu/adminspringsecurity/repository/RoleHierarchyRepository.java
@@ -1,0 +1,9 @@
+package com.jisu.adminspringsecurity.repository;
+
+import com.jisu.adminspringsecurity.domain.entity.RoleHierarchy;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RoleHierarchyRepository extends JpaRepository<RoleHierarchy, Long> {
+
+    RoleHierarchy findByChildName(String roleName);
+}

--- a/src/main/java/com/jisu/adminspringsecurity/security/configs/SecurityConfig.java
+++ b/src/main/java/com/jisu/adminspringsecurity/security/configs/SecurityConfig.java
@@ -17,7 +17,9 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.access.AccessDecisionManager;
 import org.springframework.security.access.AccessDecisionVoter;
+import org.springframework.security.access.hierarchicalroles.RoleHierarchyImpl;
 import org.springframework.security.access.vote.AffirmativeBased;
+import org.springframework.security.access.vote.RoleHierarchyVoter;
 import org.springframework.security.access.vote.RoleVoter;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.AuthenticationProvider;
@@ -35,9 +37,9 @@ import org.springframework.security.web.authentication.AuthenticationFailureHand
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.security.web.authentication.LoginUrlAuthenticationEntryPoint;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.ResourceBundle;
 
 @Configuration
 @EnableWebSecurity
@@ -75,9 +77,9 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     protected void configure(final HttpSecurity http) throws Exception {
         http
                 .authorizeRequests()
-                .antMatchers("/mypage").hasRole("USER")
-                .antMatchers("/messages").hasRole("MANAGER")
-                .antMatchers("/config").hasRole("ADMIN")
+//                .antMatchers("/mypage").hasRole("USER")
+//                .antMatchers("/messages").hasRole("MANAGER")
+//                .antMatchers("/config").hasRole("ADMIN")
 //                .antMatchers("/**").permitAll()
                 .anyRequest().authenticated()
                 .and()
@@ -155,12 +157,28 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     }
 
     private AccessDecisionManager affirmativeBased() {
-        AffirmativeBased affirmativeBased = new AffirmativeBased(getAccessDecistionVoters());
+        AffirmativeBased affirmativeBased = new AffirmativeBased(getAccessDecisionVoters());
         return affirmativeBased;
     }
 
-    private List<AccessDecisionVoter<?>> getAccessDecistionVoters() {
-        return Arrays.asList(new RoleVoter());
+    private List<AccessDecisionVoter<?>> getAccessDecisionVoters() {
+
+        List<AccessDecisionVoter<? extends Object>> accessDecisionVoters = new ArrayList<>();
+        accessDecisionVoters.add(roleVoter());
+
+        return accessDecisionVoters;
+    }
+
+    @Bean
+    public AccessDecisionVoter<? extends Object> roleVoter() {
+        RoleHierarchyVoter roleHierarchyVoter = new RoleHierarchyVoter(roleHierarchy());
+        return roleHierarchyVoter;
+    }
+
+    @Bean
+    public RoleHierarchyImpl roleHierarchy() {
+        RoleHierarchyImpl roleHierarchy = new RoleHierarchyImpl();
+        return roleHierarchy;
     }
 
     @Bean

--- a/src/main/java/com/jisu/adminspringsecurity/security/init/SecurityInitializer.java
+++ b/src/main/java/com/jisu/adminspringsecurity/security/init/SecurityInitializer.java
@@ -1,0 +1,24 @@
+package com.jisu.adminspringsecurity.security.init;
+
+import com.jisu.adminspringsecurity.service.RoleHierarchyService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.security.access.hierarchicalroles.RoleHierarchyImpl;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SecurityInitializer implements ApplicationRunner {
+
+    @Autowired
+    private RoleHierarchyService roleHierarchyService;
+
+    @Autowired
+    private RoleHierarchyImpl roleHierarchy;
+
+    @Override
+    public void run(ApplicationArguments args) throws Exception {
+        String allHierarchy = roleHierarchyService.findAllHierarchy();
+        roleHierarchy.setHierarchy(allHierarchy);
+    }
+}

--- a/src/main/java/com/jisu/adminspringsecurity/security/listener/SetupDataLoader.java
+++ b/src/main/java/com/jisu/adminspringsecurity/security/listener/SetupDataLoader.java
@@ -1,125 +1,155 @@
-//package com.jisu.adminspringsecurity.security.listener;
-//
-//import com.jisu.adminspringsecurity.domain.entity.Account;
-//import com.jisu.adminspringsecurity.domain.entity.Resources;
-//import com.jisu.adminspringsecurity.domain.entity.Role;
-//import com.jisu.adminspringsecurity.repository.ResourcesRepository;
-//import com.jisu.adminspringsecurity.repository.RoleRepository;
-//import com.jisu.adminspringsecurity.repository.UserRepository;
-//import org.springframework.beans.factory.annotation.Autowired;
-//import org.springframework.context.ApplicationListener;
-//import org.springframework.context.event.ContextRefreshedEvent;
-//import org.springframework.security.crypto.password.PasswordEncoder;
-//import org.springframework.stereotype.Component;
-//import org.springframework.transaction.annotation.Transactional;
-//
-//import java.util.HashSet;
-//import java.util.Set;
-//import java.util.concurrent.atomic.AtomicInteger;
-//
-//@Component
-//public class SetupDataLoader implements ApplicationListener<ContextRefreshedEvent> {
-//
-//    private boolean alreadySetup = false;
-//
+package com.jisu.adminspringsecurity.security.listener;
+
+import com.jisu.adminspringsecurity.domain.entity.Account;
+import com.jisu.adminspringsecurity.domain.entity.Resources;
+import com.jisu.adminspringsecurity.domain.entity.Role;
+import com.jisu.adminspringsecurity.domain.entity.RoleHierarchy;
+import com.jisu.adminspringsecurity.repository.ResourcesRepository;
+import com.jisu.adminspringsecurity.repository.RoleHierarchyRepository;
+import com.jisu.adminspringsecurity.repository.RoleRepository;
+import com.jisu.adminspringsecurity.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@Component
+public class SetupDataLoader implements ApplicationListener<ContextRefreshedEvent> {
+
+    private boolean alreadySetup = false;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private RoleRepository roleRepository;
+
+    @Autowired
+    private ResourcesRepository resourcesRepository;
+
+    @Autowired
+    private RoleHierarchyRepository roleHierarchyRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
 //    @Autowired
-//    private UserRepository userRepository;
-//
-//    @Autowired
-//    private RoleRepository roleRepository;
-//
-//    @Autowired
-//    private ResourcesRepository resourcesRepository;
-//
-//    @Autowired
-//    private PasswordEncoder passwordEncoder;
-//
-//    private static AtomicInteger count = new AtomicInteger(0);
-//
-//    @Override
-//    @Transactional
-//    public void onApplicationEvent(final ContextRefreshedEvent event) {
-//
-//        if (alreadySetup) {
-//            return;
-//        }
-//
-//        setupSecurityResources();
-//
-//        alreadySetup = true;
-//    }
-//
-//
-//
-//    private void setupSecurityResources() {
-//        Set<Role> roles = new HashSet<>();
-//        Role adminRole = createRoleIfNotFound("ROLE_ADMIN", "관리자");
-//        roles.add(adminRole);
-//        createResourceIfNotFound("/admin/**", "", roles, "url");
-//        Account account = createUserIfNotFound("admin", "pass", "admin@gmail.com", 10,  roles);
-//
-////        Set<Role> roles1 = new HashSet<>();
-////
-////        Role managerRole = createRoleIfNotFound("ROLE_MANAGER", "매니저");
-////        roles1.add(managerRole);
-////        createResourceIfNotFound("io.security.corespringsecurity.aopsecurity.method.AopMethodService.methodTest", "", roles1, "method");
-////        createResourceIfNotFound("io.security.corespringsecurity.aopsecurity.method.AopMethodService.innerCallMethodTest", "", roles1, "method");
-////        createResourceIfNotFound("execution(* io.security.corespringsecurity.aopsecurity.pointcut.*Service.*(..))", "", roles1, "pointcut");
-////        createUserIfNotFound("manager", "pass", "manager@gmail.com", 20, roles1);
-////
-////        Set<Role> roles3 = new HashSet<>();
-////
-////        Role childRole1 = createRoleIfNotFound("ROLE_USER", "회원");
-////        roles3.add(childRole1);
-////        createResourceIfNotFound("/users/**", "", roles3, "url");
-////        createUserIfNotFound("user", "pass", "user@gmail.com", 30, roles3);
-//
-//    }
-//
-//    @Transactional
-//    public Role createRoleIfNotFound(String roleName, String roleDesc) {
-//
-//        Role role = roleRepository.findByRoleName(roleName);
-//
-//        if (role == null) {
-//            role = Role.builder()
-//                    .roleName(roleName)
-//                    .roleDesc(roleDesc)
+//    private AccessIpRepository accessIpRepository;
+
+    private static AtomicInteger count = new AtomicInteger(0);
+
+    @Override
+    @Transactional
+    public void onApplicationEvent(final ContextRefreshedEvent event) {
+
+        if (alreadySetup) {
+            return;
+        }
+
+        setupSecurityResources();
+
+//        setupAccessIpData();
+
+        alreadySetup = true;
+    }
+
+
+
+    private void setupSecurityResources() {
+        Set<Role> roles = new HashSet<>();
+        Role adminRole = createRoleIfNotFound("ROLE_ADMIN", "관리자");
+        roles.add(adminRole);
+        createResourceIfNotFound("/admin/**", "", roles, "url");
+        createUserIfNotFound("admin@gmail.com", "admin@admin.com", "pass", roles);
+        Role managerRole = createRoleIfNotFound("ROLE_MANAGER", "매니저권한");
+        Role userRole = createRoleIfNotFound("ROLE_USER", "사용자권한");
+        createRoleHierarchyIfNotFound(managerRole, adminRole);
+        createRoleHierarchyIfNotFound(userRole, managerRole);
+
+
+    }
+
+    @Transactional
+    public Role createRoleIfNotFound(String roleName, String roleDesc) {
+
+        Role role = roleRepository.findByRoleName(roleName);
+
+        if (role == null) {
+            role = Role.builder()
+                    .roleName(roleName)
+                    .roleDesc(roleDesc)
+                    .build();
+        }
+        return roleRepository.save(role);
+    }
+
+    @Transactional
+    public Account createUserIfNotFound(final String userName, final String email, final String password, Set<Role> roleSet) {
+
+        Account account = userRepository.findByUsername(userName);
+
+        if (account == null) {
+            account = Account.builder()
+                    .username(userName)
+                    .email(email)
+                    .password(passwordEncoder.encode(password))
+                    .userRoles(roleSet)
+                    .build();
+        }
+        return userRepository.save(account);
+    }
+
+    @Transactional
+    public Resources createResourceIfNotFound(String resourceName, String httpMethod, Set<Role> roleSet, String resourceType) {
+        Resources resources = resourcesRepository.findByResourceNameAndHttpMethod(resourceName, httpMethod);
+
+        if (resources == null) {
+            resources = Resources.builder()
+                    .resourceName(resourceName)
+                    .roleSet(roleSet)
+                    .httpMethod(httpMethod)
+                    .resourceType(resourceType)
+                    .orderNum(count.incrementAndGet())
+                    .build();
+        }
+        return resourcesRepository.save(resources);
+    }
+
+    @Transactional
+    public void createRoleHierarchyIfNotFound(Role childRole, Role parentRole) {
+
+        RoleHierarchy roleHierarchy = roleHierarchyRepository.findByChildName(parentRole.getRoleName());
+        if (roleHierarchy == null) {
+            roleHierarchy = RoleHierarchy.builder()
+                    .childName(parentRole.getRoleName())
+                    .build();
+        }
+        RoleHierarchy parentRoleHierarchy = roleHierarchyRepository.save(roleHierarchy);
+
+        roleHierarchy = roleHierarchyRepository.findByChildName(childRole.getRoleName());
+        if (roleHierarchy == null) {
+            roleHierarchy = RoleHierarchy.builder()
+                    .childName(childRole.getRoleName())
+                    .build();
+        }
+
+        RoleHierarchy childRoleHierarchy = roleHierarchyRepository.save(roleHierarchy);
+        childRoleHierarchy.setParentName(parentRoleHierarchy);
+    }
+
+//    private void setupAccessIpData() {
+//        AccessIp byIpAddress = accessIpRepository.findByIpAddress("127.0.0.1");
+//        if (byIpAddress == null) {
+//            AccessIp accessIp = AccessIp.builder()
+//                    .ipAddress("127.0.0.1")
 //                    .build();
+//            accessIpRepository.save(accessIp);
 //        }
-//        return roleRepository.save(role);
 //    }
-//
-//    @Transactional
-//    public Account createUserIfNotFound(String userName, String password, String email, int age, Set<Role> roleSet) {
-//
-//        Account account = userRepository.findByUsername(userName);
-//
-//        if (account == null) {
-//            account = Account.builder()
-//                    .username(userName)
-//                    .email(email)
-//                    .age(age)
-//                    .password(passwordEncoder.encode(password))
-//                    .userRoles(roleSet)
-//                    .build();
-//        }
-//        return userRepository.save(account);
-//    }
-//
-//    @Transactional
-//    public Resources createResourceIfNotFound(String resourceName, String httpMethod, Set<Role> roleSet, String resourceType) {
-//        Resources resources = resourcesRepository.findByResourceNameAndHttpMethod(resourceName, httpMethod);
-//
-//        if (resources == null) {
-//            resources = Resources.builder()
-//                    .resourceName(resourceName)
-//                    .roleSet(roleSet)
-//                    .httpMethod(httpMethod)
-//                    .resourceType(resourceType)
-//                    .orderNum(count.incrementAndGet())
-//                    .build();
-//        }
-//        return resourcesRepository.save(resources);
-//    }
-//}
+}

--- a/src/main/java/com/jisu/adminspringsecurity/service/RoleHierarchyService.java
+++ b/src/main/java/com/jisu/adminspringsecurity/service/RoleHierarchyService.java
@@ -1,0 +1,6 @@
+package com.jisu.adminspringsecurity.service;
+
+public interface RoleHierarchyService {
+
+    String findAllHierarchy();
+}

--- a/src/main/java/com/jisu/adminspringsecurity/service/impl/RoleHierarchyServiceImpl.java
+++ b/src/main/java/com/jisu/adminspringsecurity/service/impl/RoleHierarchyServiceImpl.java
@@ -1,0 +1,38 @@
+package com.jisu.adminspringsecurity.service.impl;
+
+import com.jisu.adminspringsecurity.domain.entity.RoleHierarchy;
+import com.jisu.adminspringsecurity.repository.RoleHierarchyRepository;
+import com.jisu.adminspringsecurity.service.RoleHierarchyService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Iterator;
+import java.util.List;
+
+@Service
+public class RoleHierarchyServiceImpl implements RoleHierarchyService {
+    @Autowired
+    private RoleHierarchyRepository roleHierarchyRepository;
+
+    @Transactional
+    @Override
+    public String findAllHierarchy() {
+
+        List<RoleHierarchy> rolesHierarchy = roleHierarchyRepository.findAll();
+
+        Iterator<RoleHierarchy> itr = rolesHierarchy.iterator();
+        StringBuffer concatedRoles = new StringBuffer();
+        while (itr.hasNext()) {
+            RoleHierarchy model = itr.next();
+            if (model.getParentName() != null) {
+                concatedRoles.append(model.getParentName().getChildName());
+                concatedRoles.append(" > ");
+                concatedRoles.append(model.getChildName());
+                concatedRoles.append("\n");
+            }
+        }
+        return concatedRoles.toString();
+
+    }
+}


### PR DESCRIPTION
admin 권한일 떄 아래 권한들 다 가지는것은 RoleHierarchy 라는 클래스에서 설정할 수 있다.
RoleHierarchy  테이블내에서 연관관계 맺어서 패런츠랑 차일드 맺는다.
RoleHierarchyRepository로 차일드findByChildName 이름 가죠ㅕ오기.
RoleHierarchyServiceImpl에서 findAllHierarchy =>
스트링 버퍼로 > 줄바꿈을 해줘서 리턴한다.
SecurityInitializer 이클래스를 스프링 띄울때 시큐리티에 설정하는 방법이다.
RoleHierarchyImpl  구현체에 setHierarchy 가 있는데 RoleHierarchyServiceImpl에서 리턴받은 스트링 값을 넣어준다.